### PR TITLE
Update README.md - put pnpm install before pnpm drizzle-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ Create `.env` file
 cp .env.example .env
 ```
 
-Create sqlite db / push schema
-
-```sh
-pnpm drizzle-kit push
-```
-
 Install dependencies
 
 ```sh
 pnpm install
+```
+
+Create sqlite db / push schema
+
+```sh
+pnpm drizzle-kit push
 ```
 
 Run


### PR DESCRIPTION
Simple reordering of install steps in the README

`pnpm drizzle-kit push` will fail if you just ran `degit` to copy the repo, and you haven't yet installed deps

***

Thanks for making this starter!!