### PR TITLE
:bug: add unique to table id field

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,7 +3,8 @@ import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
 export const tasks = sqliteTable("tasks", {
   id: integer("id", { mode: "number" })
-    .primaryKey({ autoIncrement: true }),
+    .primaryKey({ autoIncrement: true })
+    .unique(),
   name: text("name")
     .notNull(),
   done: integer("done", { mode: "boolean" })


### PR DESCRIPTION
Specifying "id" as primaryKey is not enough for drizzle consider the field as unique. So we need to be explicit about that.

FIXES:
- https://github.com/w3cj/hono-open-api-starter/issues/21