### PR TITLE
feat: Made the createTestApp able to pass the router Schema type

### DIFF
--- a/src/lib/create-app.ts
+++ b/src/lib/create-app.ts
@@ -1,3 +1,5 @@
+import type { Schema } from "hono";
+
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { notFound, onError, serveEmojiFavicon } from "stoker/middlewares";
 import { defaultHook } from "stoker/openapi";
@@ -23,6 +25,6 @@ export default function createApp() {
   return app;
 }
 
-export function createTestApp<R extends AppOpenAPI>(router: R) {
+export function createTestApp<S extends Schema>(router: AppOpenAPI<S>) {
   return createApp().route("/", router);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { OpenAPIHono, RouteConfig, RouteHandler } from "@hono/zod-openapi";
+import type { Schema } from "hono";
 import type { PinoLogger } from "hono-pino";
 
 export interface AppBindings {
@@ -7,6 +8,7 @@ export interface AppBindings {
   };
 };
 
-export type AppOpenAPI = OpenAPIHono<AppBindings>;
+// eslint-disable-next-line ts/no-empty-object-type
+export type AppOpenAPI<S extends Schema = {}> = OpenAPIHono<AppBindings, S>;
 
 export type AppRouteHandler<R extends RouteConfig> = RouteHandler<R, AppBindings>;

--- a/src/routes/tasks/tasks.test.ts
+++ b/src/routes/tasks/tasks.test.ts
@@ -8,7 +8,7 @@ import { ZodIssueCode } from "zod";
 
 import env from "@/env";
 import { ZOD_ERROR_CODES, ZOD_ERROR_MESSAGES } from "@/lib/constants";
-import createApp from "@/lib/create-app";
+import { createTestApp } from "@/lib/create-app";
 
 import router from "./tasks.index";
 
@@ -16,7 +16,7 @@ if (env.NODE_ENV !== "test") {
   throw new Error("NODE_ENV must be 'test'");
 }
 
-const client = testClient(createApp().route("/", router));
+const client = testClient(createTestApp(router));
 
 describe("tasks routes", () => {
   beforeAll(async () => {


### PR DESCRIPTION
After this commit, the function createTestApp can be used with the testClient function and the types of the router will flow through.

First I updated the AppOpenAPI type to accept a generic Schema or a empty default. It's the same way as the OpenAPIHono type.

Then I changed the createTestApp to accept a schema generic and pass it to AppOpenAPI type.

Finally in the tasks.test it can now use this function and the types will work.