### PR TITLE
remove the usage of deprecated `reqId()` and use hono's `requestId()` instead as recommended

### DIFF
--- a/src/lib/create-app.ts
+++ b/src/lib/create-app.ts
@@ -1,4 +1,5 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
+import { requestId } from "hono/request-id";
 import { notFound, onError, serveEmojiFavicon } from "stoker/middlewares";
 import { defaultHook } from "stoker/openapi";
 
@@ -15,8 +16,9 @@ export function createRouter() {
 
 export default function createApp() {
   const app = createRouter();
-  app.use(serveEmojiFavicon("📝"));
-  app.use(pinoLogger());
+  app.use(requestId())
+    .use(serveEmojiFavicon("📝"))
+    .use(pinoLogger());
 
   app.notFound(notFound);
   app.onError(onError);

--- a/src/middlewares/pino-logger.ts
+++ b/src/middlewares/pino-logger.ts
@@ -9,8 +9,5 @@ export function pinoLogger() {
     pino: pino({
       level: env.LOG_LEVEL || "info",
     }, env.NODE_ENV === "production" ? undefined : pretty()),
-    http: {
-      reqId: () => crypto.randomUUID(),
-    },
   });
 }


### PR DESCRIPTION
`hono-pino`'s `reqId()` is **deprecated** and will be removed in 1.0.0.

> Note: hono's `requestId()` still defaults to `crypto.randomUUID()`.