### PR TITLE
Update targetKey for apiReference to default http client to javascript

### DIFF
--- a/src/lib/configure-open-api.ts
+++ b/src/lib/configure-open-api.ts
@@ -19,7 +19,7 @@ export default function configureOpenAPI(app: AppOpenAPI) {
       theme: "kepler",
       layout: "classic",
       defaultHttpClient: {
-        targetKey: "javascript",
+        targetKey: "js",
         clientKey: "fetch",
       },
       spec: {


### PR DESCRIPTION
set targetKey to 'js' in order for hono-api-reference to use javascript as the default http client